### PR TITLE
Update dependencies for advanced attention backends

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pillow
 huggingface_hub
 triton; platform_system!="Windows"
 triton-windows; platform_system=="Windows"
+sageattention
+flash-attn --no-build-isolation; platform_system!="Windows"


### PR DESCRIPTION
- Add `sageattention` and `flash-attn` to `requirements.txt` to enable high-performance attention modes.
- Note: This commit updates dependencies required for the `flash_attention_2` and `sparse_sage` modes previously implemented.